### PR TITLE
[UR][Offload] Add "offload" as an adapter to the various registries

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -1421,6 +1421,8 @@ typedef enum ur_adapter_backend_t {
   UR_ADAPTER_BACKEND_HIP = 4,
   /// The backend is Native CPU
   UR_ADAPTER_BACKEND_NATIVE_CPU = 5,
+  /// The backend is liboffload
+  UR_ADAPTER_BACKEND_OFFLOAD = 0x100,
   /// @cond
   UR_ADAPTER_BACKEND_FORCE_UINT32 = 0x7fffffff
   /// @endcond
@@ -1800,6 +1802,8 @@ typedef enum ur_platform_backend_t {
   UR_PLATFORM_BACKEND_HIP = 4,
   /// The backend is Native CPU
   UR_PLATFORM_BACKEND_NATIVE_CPU = 5,
+  /// The backend is liboffload
+  UR_PLATFORM_BACKEND_OFFLOAD = 0x100,
   /// @cond
   UR_PLATFORM_BACKEND_FORCE_UINT32 = 0x7fffffff
   /// @endcond

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -2356,6 +2356,9 @@ inline std::ostream &operator<<(std::ostream &os,
   case UR_ADAPTER_BACKEND_NATIVE_CPU:
     os << "UR_ADAPTER_BACKEND_NATIVE_CPU";
     break;
+  case UR_ADAPTER_BACKEND_OFFLOAD:
+    os << "UR_ADAPTER_BACKEND_OFFLOAD";
+    break;
   default:
     os << "unknown enumerator";
     break;
@@ -2552,6 +2555,9 @@ inline std::ostream &operator<<(std::ostream &os,
     break;
   case UR_PLATFORM_BACKEND_NATIVE_CPU:
     os << "UR_PLATFORM_BACKEND_NATIVE_CPU";
+    break;
+  case UR_PLATFORM_BACKEND_OFFLOAD:
+    os << "UR_PLATFORM_BACKEND_OFFLOAD";
     break;
   default:
     os << "unknown enumerator";

--- a/scripts/core/adapter.yml
+++ b/scripts/core/adapter.yml
@@ -206,6 +206,9 @@ etors:
     - name: NATIVE_CPU
       value: "5"
       desc: "The backend is Native CPU"
+    - name: OFFLOAD
+      value: "0x100"
+      desc: "The backend is liboffload"
 --- #--------------------------------------------------------------------------
 type: enum
 desc: "Minimum level of messages to be processed by the logger."

--- a/scripts/core/manifests.yml
+++ b/scripts/core/manifests.yml
@@ -61,3 +61,10 @@ name: native_cpu
 backend: $X_ADAPTER_BACKEND_NATIVE_CPU
 device_types:
     - $X_DEVICE_TYPE_CPU
+--- #--------------------------------------------------------------------------
+type: manifest
+name: offload
+backend: $X_ADAPTER_BACKEND_OFFLOAD
+device_types:
+    - $X_DEVICE_TYPE_CPU
+    - $X_DEVICE_TYPE_GPU

--- a/scripts/core/platform.yml
+++ b/scripts/core/platform.yml
@@ -279,3 +279,6 @@ etors:
     - name: NATIVE_CPU
       value: "5"
       desc: "The backend is Native CPU"
+    - name: OFFLOAD
+      value: "0x100"
+      desc: "The backend is liboffload"

--- a/source/adapters/CMakeLists.txt
+++ b/source/adapters/CMakeLists.txt
@@ -76,6 +76,7 @@ endif()
 
 if(UR_BUILD_ADAPTER_OFFLOAD)
     add_ur_adapter_subdirectory(offload)
+    list(APPEND TEMP_LIST "offload")
 endif()
 
 set(UR_ADAPTERS_LIST "${TEMP_LIST}" CACHE STRING "" FORCE)

--- a/source/adapters/offload/adapter.cpp
+++ b/source/adapters/offload/adapter.cpp
@@ -85,7 +85,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetInfo(ur_adapter_handle_t,
 
   switch (propName) {
   case UR_ADAPTER_INFO_BACKEND:
-    return ReturnValue(UR_ADAPTER_BACKEND_CUDA); // TODO: Return a proper value
+    return ReturnValue(UR_ADAPTER_BACKEND_OFFLOAD);
   case UR_ADAPTER_INFO_REFERENCE_COUNT:
     return ReturnValue(Adapter.RefCount.load());
   default:

--- a/source/adapters/offload/platform.cpp
+++ b/source/adapters/offload/platform.cpp
@@ -49,7 +49,7 @@ urPlatformGetInfo(ur_platform_handle_t hPlatform, ur_platform_info_t propName,
   case UR_PLATFORM_INFO_PROFILE:
     return ReturnValue("FULL_PROFILE");
   case UR_PLATFORM_INFO_BACKEND:
-    olInfo = OL_PLATFORM_INFO_BACKEND;
+    return ReturnValue(UR_PLATFORM_BACKEND_OFFLOAD);
     break;
   default:
     return UR_RESULT_ERROR_INVALID_ENUMERATION;
@@ -68,24 +68,6 @@ urPlatformGetInfo(ur_platform_handle_t hPlatform, ur_platform_info_t propName,
             olGetPlatformInfo(reinterpret_cast<ol_platform_handle_t>(hPlatform),
                               olInfo, propSize, pPropValue)) {
       return offloadResultToUR(Res);
-    }
-
-    // Need to explicitly map this type
-    if (olInfo == OL_PLATFORM_INFO_BACKEND) {
-      auto urPropPtr = reinterpret_cast<ur_platform_backend_t *>(pPropValue);
-      auto olPropPtr = reinterpret_cast<ol_platform_backend_t *>(pPropValue);
-
-      switch (*olPropPtr) {
-      case OL_PLATFORM_BACKEND_CUDA:
-        *urPropPtr = UR_PLATFORM_BACKEND_CUDA;
-        break;
-      case OL_PLATFORM_BACKEND_AMDGPU:
-        *urPropPtr = UR_PLATFORM_BACKEND_HIP;
-        break;
-      default:
-        *urPropPtr = UR_PLATFORM_BACKEND_UNKNOWN;
-        break;
-      }
     }
   }
 

--- a/source/loader/ur_adapter_registry.hpp
+++ b/source/loader/ur_adapter_registry.hpp
@@ -40,6 +40,7 @@ struct FilterTerm {
       {"cuda", UR_ADAPTER_BACKEND_CUDA},
       {"hip", UR_ADAPTER_BACKEND_HIP},
       {"native_cpu", UR_ADAPTER_BACKEND_NATIVE_CPU},
+      {"offload", UR_ADAPTER_BACKEND_OFFLOAD},
   };
 
   bool matchesBackend(const ur_adapter_backend_t &match_backend) const {

--- a/source/loader/ur_lib.cpp
+++ b/source/loader/ur_lib.cpp
@@ -251,13 +251,15 @@ ur_result_t urDeviceGetSelected(ur_platform_handle_t hPlatform,
                                 uint32_t NumEntries,
                                 ur_device_handle_t *phDevices,
                                 uint32_t *pNumDevices) {
-  constexpr std::pair<const ur_platform_backend_t, const char *> adapters[6] = {
+  constexpr std::pair<const ur_platform_backend_t, const char *> adapters[7] = {
       {UR_PLATFORM_BACKEND_UNKNOWN, "*"},
       {UR_PLATFORM_BACKEND_LEVEL_ZERO, "level_zero"},
       {UR_PLATFORM_BACKEND_OPENCL, "opencl"},
       {UR_PLATFORM_BACKEND_CUDA, "cuda"},
       {UR_PLATFORM_BACKEND_HIP, "hip"},
-      {UR_PLATFORM_BACKEND_NATIVE_CPU, "native_cpu"}};
+      {UR_PLATFORM_BACKEND_NATIVE_CPU, "native_cpu"},
+      {UR_PLATFORM_BACKEND_OFFLOAD, "offload"},
+    };
 
   if (!hPlatform) {
     return UR_RESULT_ERROR_INVALID_NULL_HANDLE;

--- a/source/loader/ur_manifests.hpp
+++ b/source/loader/ur_manifests.hpp
@@ -79,5 +79,12 @@ const std::vector<ur_adapter_manifest> ur_adapter_manifests = {
      {
          UR_DEVICE_TYPE_CPU,
      }},
+    {"offload",
+     MAKE_LIBRARY_NAME("ur_adapter_offload", "0"),
+     UR_ADAPTER_BACKEND_OFFLOAD,
+     {
+         UR_DEVICE_TYPE_CPU,
+         UR_DEVICE_TYPE_GPU,
+     }},
 };
 } // namespace ur_loader


### PR DESCRIPTION
This adds "offload" to several locations, meaning that:
* It will be initialised by the loader and iterated like other adapters.
* ONEAPI_DEVICE_SELECTOR="offload:*" works (note that this is an extension to the ONEAPI_DEVICE_SELECTOR format).
* Platforms and adapters now report themselves as "OFFLOAD" rather than "CUDA" or "HIP".